### PR TITLE
Load service impls with TCCL and current classloader

### DIFF
--- a/server/src/main/java/org/asciidoctor/diagram/CommandServer.java
+++ b/server/src/main/java/org/asciidoctor/diagram/CommandServer.java
@@ -37,8 +37,12 @@ public class CommandServer {
     {
         Map<String, DiagramGenerator> generatorMap = new HashMap<String, DiagramGenerator>();
 
-        ServiceLoader<DiagramGenerator> generatorLoader = ServiceLoader.load(DiagramGenerator.class);
+        ServiceLoader<DiagramGenerator> generatorLoader = ServiceLoader.load(DiagramGenerator.class, CommandServer.class.getClassLoader());
         for (DiagramGenerator generator : generatorLoader) {
+            generatorMap.put(generator.getName(), generator);
+        }
+        ServiceLoader<DiagramGenerator> generatorLoaderTCCL = ServiceLoader.load(DiagramGenerator.class);
+        for (DiagramGenerator generator : generatorLoaderTCCL) {
             generatorMap.put(generator.getName(), generator);
         }
         return generatorMap;


### PR DESCRIPTION
This PR changes the discovery of processors to also use the classloader of the CommandServer instead of relying on the TCCL which makes using this extension impossible in AsciidoctorJ.
It should fix https://github.com/asciidoctor/asciidoctor-diagram/issues/159 
