### PR TITLE
Support Syntrax diagrams

### DIFF
--- a/syntrax/build.gradle
+++ b/syntrax/build.gradle
@@ -1,12 +1,11 @@
 repositories {
-    mavenLocal()
     mavenCentral()
-    jcenter()
+    mavenLocal()
 }
 
 dependencies {
     implementation project(':server')
-    implementation 'org.atp-fivt:jsyntrax:1.32'
+    implementation 'org.atp-fivt:jsyntrax:1.35'
     testImplementation project(':server')
     testImplementation project(path: ':server', configuration: 'tests')
 }

--- a/syntrax/build.gradle
+++ b/syntrax/build.gradle
@@ -1,0 +1,12 @@
+repositories {
+    mavenLocal()
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation project(':server')
+    implementation 'org.atp-fivt:jsyntrax:1.32'
+    testImplementation project(':server')
+    testImplementation project(path: ':server', configuration: 'tests')
+}

--- a/syntrax/src/main/java/org/asciidoctor/diagram/syntrax/Syntrax.java
+++ b/syntrax/src/main/java/org/asciidoctor/diagram/syntrax/Syntrax.java
@@ -1,0 +1,68 @@
+package org.asciidoctor.diagram.syntrax;
+
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.commons.cli.ParseException;
+import org.asciidoctor.diagram.*;
+import org.atpfivt.jsyntrax.InputArguments;
+import org.atpfivt.jsyntrax.styles.StyleConfig;
+import org.atpfivt.jsyntrax.util.SVGTranscoder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.atpfivt.jsyntrax.Main.generateSVG;
+import static org.atpfivt.jsyntrax.Main.getStyleConfig;
+
+public class Syntrax implements DiagramGenerator {
+    public static final MimeType DEFAULT_OUTPUT_FORMAT = MimeType.SVG;
+
+    @Override
+    public String getName() {
+        return "syntrax";
+    }
+
+    @Override
+    public ResponseData generate(Request request) throws IOException {
+        MimeType format = request.headers.getValue(HTTPHeader.ACCEPT);
+        if (format == null) {
+            format = DEFAULT_OUTPUT_FORMAT;
+        }
+
+        if (!format.equals(MimeType.SVG) && !format.equals(MimeType.PNG)) {
+            throw new IOException("Unsupported output format: " + format);
+        }
+
+        String[] options = new String[0];
+        String optionString = request.headers.getValue(HTTPHeader.OPTIONS);
+        if (optionString != null) {
+            options = optionString.split(" ");
+        }
+
+        InputArguments iArgs;
+        try {
+            iArgs = new InputArguments(options);
+        } catch (ParseException e) {
+            throw new IOException(e);
+        }
+
+        StyleConfig style = getStyleConfig(iArgs);
+        String title = iArgs.getTitle();
+
+        String result = generateSVG(title, style, new String(request.data, StandardCharsets.UTF_8));
+        byte[] responseData = result.getBytes(StandardCharsets.UTF_8);
+
+        // transcode SVG to PNG if needed
+        try {
+            if (format.equals(MimeType.PNG)) {
+                responseData = SVGTranscoder.svg2Png(result);
+            }
+        } catch (TranscoderException e) {
+            throw new IOException(e);
+        }
+
+        return new ResponseData(
+                format,
+                responseData
+        );
+    }
+}

--- a/syntrax/src/main/resources/META-INF/services/org.asciidoctor.diagram.DiagramGenerator
+++ b/syntrax/src/main/resources/META-INF/services/org.asciidoctor.diagram.DiagramGenerator
@@ -1,0 +1,1 @@
+org.asciidoctor.diagram.syntrax.Syntrax

--- a/syntrax/src/test/java/org/asciidoctor/diagram/syntrax/SyntraxTest.java
+++ b/syntrax/src/test/java/org/asciidoctor/diagram/syntrax/SyntraxTest.java
@@ -1,26 +1,34 @@
 package org.asciidoctor.diagram.syntrax;
 
-import org.asciidoctor.diagram.*;
+import org.asciidoctor.diagram.Assert;
+import org.asciidoctor.diagram.HTTPHeader;
+import org.asciidoctor.diagram.HTTPHeaders;
+import org.asciidoctor.diagram.MimeType;
+import org.asciidoctor.diagram.Request;
+import org.asciidoctor.diagram.ResponseData;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class SyntraxTest {
 
-    public static final String SYNTRAX_INPUT = """
-            jsyntrax(stack(
-             line('attribute', '/(attribute) identifier', 'of'),
-             line(choice(toploop('/entity_designator', ','), 'others', 'all'), ':'),
-             line('/entity_class', 'is', '/expression', ';')
-            ),\s
-            [
-              'entity_class': 'https://www.google.com/#q=vhdl+entity+class',
-              '(attribute) identifier': 'http://en.wikipedia.com/wiki/VHDL'
-            ])""";
+    private static byte[] SYNTRAX_INPUT;
+
+    @BeforeClass
+    public static void setUP() {
+        try {
+            SYNTRAX_INPUT = Files.readAllBytes(Paths.get("src", "test", "resources", "testinput.spec"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
@@ -38,7 +46,7 @@ public class SyntraxTest {
         ResponseData response = new Syntrax().generate(new Request(
                 URI.create("/syntrax"),
                 h,
-                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+                SYNTRAX_INPUT
         ));
 
         Assert.assertIsSVG(response);
@@ -53,7 +61,7 @@ public class SyntraxTest {
         ResponseData response = new Syntrax().generate(new Request(
                 URI.create("/syntrax"),
                 h,
-                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+                SYNTRAX_INPUT
         ));
 
         Assert.assertIsPNG(response);
@@ -71,7 +79,7 @@ public class SyntraxTest {
         new Syntrax().generate(new Request(
                 URI.create("/syntrax"),
                 h,
-                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+                SYNTRAX_INPUT
         ));
     }
 }

--- a/syntrax/src/test/java/org/asciidoctor/diagram/syntrax/SyntraxTest.java
+++ b/syntrax/src/test/java/org/asciidoctor/diagram/syntrax/SyntraxTest.java
@@ -1,0 +1,77 @@
+package org.asciidoctor.diagram.syntrax;
+
+import org.asciidoctor.diagram.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public class SyntraxTest {
+
+    public static final String SYNTRAX_INPUT = """
+            jsyntrax(stack(
+             line('attribute', '/(attribute) identifier', 'of'),
+             line(choice(toploop('/entity_designator', ','), 'others', 'all'), ':'),
+             line('/entity_class', 'is', '/expression', ';')
+            ),\s
+            [
+              'entity_class': 'https://www.google.com/#q=vhdl+entity+class',
+              '(attribute) identifier': 'http://en.wikipedia.com/wiki/VHDL'
+            ])""";
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void testTestGetName() {
+        org.junit.Assert.assertEquals("syntrax", new Syntrax().getName());
+    }
+
+    @Test
+    public void testGenerateSVG() throws IOException {
+        HTTPHeaders h = new HTTPHeaders();
+        h.putValue(HTTPHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_UTF8);
+        h.putValue(HTTPHeader.ACCEPT, MimeType.SVG);
+
+        ResponseData response = new Syntrax().generate(new Request(
+                URI.create("/syntrax"),
+                h,
+                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+        ));
+
+        Assert.assertIsSVG(response);
+    }
+
+    @Test
+    public void testGeneratePNG() throws IOException {
+        HTTPHeaders h = new HTTPHeaders();
+        h.putValue(HTTPHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_UTF8);
+        h.putValue(HTTPHeader.ACCEPT, MimeType.PNG);
+
+        ResponseData response = new Syntrax().generate(new Request(
+                URI.create("/syntrax"),
+                h,
+                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+        ));
+
+        Assert.assertIsPNG(response);
+    }
+
+    @Test
+    public void testGenerateWithWrongFormat() throws IOException {
+        exceptionRule.expect(IOException.class);
+        exceptionRule.expectMessage("Unsupported output format");
+
+        HTTPHeaders h = new HTTPHeaders();
+        h.putValue(HTTPHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_UTF8);
+        h.putValue(HTTPHeader.ACCEPT, MimeType.TEXT_PLAIN_UTF8);
+
+        new Syntrax().generate(new Request(
+                URI.create("/syntrax"),
+                h,
+                SYNTRAX_INPUT.getBytes(StandardCharsets.UTF_8)
+        ));
+    }
+}

--- a/syntrax/src/test/resources/testinput.spec
+++ b/syntrax/src/test/resources/testinput.spec
@@ -1,0 +1,9 @@
+jsyntrax(stack(
+   line('attribute', '/(attribute) identifier', 'of'),
+   line(choice(toploop('/entity_designator', ','), 'others', 'all'), ':'),
+   line('/entity_class', 'is', '/expression', ';')
+),
+[
+   'entity_class': 'https://www.google.com/#q=vhdl+entity+class',
+   '(attribute) identifier': 'http://en.wikipedia.com/wiki/VHDL'
+])


### PR DESCRIPTION
Hello @pepijnve !

this implements an idea you proposed some time ago here: https://github.com/asciidoctor/asciidoctor-diagram/pull/349#issuecomment-817300687

We need this to reduce the time currently needed to compile a documentation which has a large number of `syntrax` diagrams.

I see that unfortunately the main branch is broken now which is somehow related to Java 8->Java 11 upgrade.

From our side, we downgraded JSyntrax to Java8 specifically for the library to be compatible with asciidoctor-diagram :-) 

I am open to sync very quickly to solve all the Java versions issues.