### PR TITLE
Use Java11 version of JSyntrax

### DIFF
--- a/syntrax/build.gradle
+++ b/syntrax/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(':server')
-    implementation 'org.atp-fivt:jsyntrax:1.35'
+    implementation 'org.atp-fivt:jsyntrax:1.36'
     testImplementation project(':server')
     testImplementation project(path: ':server', configuration: 'tests')
 }


### PR DESCRIPTION
This one updates the version of `jsyntrax` to 1.36, which was built with bytecode version 55 (Java 11).

(jsyntrax has been originally implemented in Java 11 and was downgraded to 8 just to merge it with this project 😄  ) 

Concerning the issue with access to `org.atpfivt.jsyntrax.InputArguments` constructor: it used to be package-private in versions before 1.35, so just please double-check the classpath!